### PR TITLE
Added kafka message producer from single log router

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sniffio==1.3.1
 starlette==0.44.0
 typing-extensions==4.13.2
 uvicorn==0.33.0
+confluent-kafka==2.3.0

--- a/server/routers/log_router.py
+++ b/server/routers/log_router.py
@@ -1,10 +1,24 @@
 from fastapi import APIRouter, HTTPException, Request, Response, status
 import datetime
+import os
+import json
+from confluent_kafka import Producer
 
 log_router = APIRouter(
     prefix="/log",
     tags=["Log"],
 )
+
+KAFKA_BROKER = os.environ.get("KAFKA_BROKER", "kafka:9093")
+KAFKA_TOPIC_RAW = os.environ.get("KAFKA_TOPIC_RAW", "raw_logs")
+
+producer = Producer({'bootstrap.servers': KAFKA_BROKER})
+
+def delivery_report(err, msg):
+    if err is not None:
+        print(f"Delivery failed for record {msg.key()}: {err}")
+    else:
+        print(f"Record {msg.key()} successfully produced to {msg.topic()} [{msg.partition()}] at offset {msg.offset()}")
 
 @log_router.post("/", summary="Add Logs")
 async def add_single_log(request: Request):
@@ -20,6 +34,15 @@ async def add_single_log(request: Request):
         parsed_data["timestamp"] = datetime.datetime.now()
 
         print(parsed_data)
+
+        producer.produce(
+            KAFKA_TOPIC_RAW,
+            key=None,
+            value=json.dumps(parsed_data).encode('utf-8'),
+            callback=delivery_report
+        )
+        
+        producer.flush()
 
         return Response(
             status_code=status.HTTP_200_OK,


### PR DESCRIPTION
This change is publishing to the kafka raw_logs topic. Default value set to value from `docker-compose.yml` : `BROKER://kafka:9093`.

New issue from this:
We ourselves might have to subscribe to our own application to store and manage our own application log instead of `print()`!